### PR TITLE
Implement NextJS Server-Side CSV Data Reading and Client-Side Map Display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.2",
         "@types/mapbox-gl": "^3.4.0",
+        "csv-parse": "^5.5.6",
         "mapbox-gl": "^3.7.0",
         "next": "13.5.6",
         "react": "^18",
@@ -1747,6 +1748,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6502,6 +6508,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.1.2",
     "@types/mapbox-gl": "^3.4.0",
+    "csv-parse": "^5.5.6",
     "mapbox-gl": "^3.7.0",
     "next": "13.5.6",
     "react": "^18",

--- a/src/app/map/helpers.ts
+++ b/src/app/map/helpers.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from "fs";
+import { CsvParseOptions, ResaleData } from "@/app/map/types";
+import { parse } from "csv-parse/sync";
+
+const readAndParseCSV = async (): Promise<ResaleData> => {
+  // Read the CSV file located in the public directory.
+  const filePath: string = process.cwd() + '/public/data/resale-data.csv';
+  let fileContent: string = await fs.readFile(filePath, 'utf8');
+
+  // Remove the BOM (Byte Order Mark) if it's present.
+  if (fileContent.charCodeAt(0) === 0xFEFF) {
+    fileContent = fileContent.slice(1);
+  }
+
+  const CsvParseOptions: CsvParseOptions = {
+    columns: true, // Return records as objects with column headers
+    skip_empty_lines: true, // Skip any empty lines
+    delimiter: ',', // Explicitly define the delimiter (comma in this case)
+    trim: true, // Trim whitespace around fields
+  }
+
+  // Parse the CSV content using csv-parse
+  return parse(fileContent, CsvParseOptions);
+}
+
+export {
+  readAndParseCSV
+}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,16 +1,23 @@
-import React from "react";
+import React from "react"
 import MapboxContainer from "@/app/shared-components/react-mapbox/mapbox-container"
+import { readAndParseCSV } from "@/app/map/helpers"
+import { ResaleData } from "@/app/map/types"
 
-// Default export for the map page.
-const MapPage = () => {
+/* This component is initially rendered on the server, enabling secure data fetching
+ * such as accessing a database or, in this case, reading a CSV file containing
+ * Vancouver resale data from 2023. For more details, refer to:
+ * https://vercel.com/guides/loading-static-file-nextjs-api-route */
+const MapPage = async () => {
+  // Read the CSV file located in the public directory.
+  const records: ResaleData = await readAndParseCSV();
+
   return (
     <div className="map-main-container">
-      Hello, I will be the map page :)
-      <div>
-        <MapboxContainer/>
-      </div>
+      <MapboxContainer {...{
+        records
+      }} />
     </div>
-  );
-};
+  )
+}
 
-export default MapPage;
+export default MapPage

--- a/src/app/map/types.ts
+++ b/src/app/map/types.ts
@@ -1,0 +1,20 @@
+export interface CsvParseOptions {
+  columns: boolean; // Parse CSV into objects with headers as keys
+  skip_empty_lines: boolean; // Skip empty lines
+  delimiter: string; // Field delimiter (e.g., ',')
+  trim: boolean; // Trim whitespace around fields
+}
+
+export interface Property {
+  id: string;
+  area_sqft: string;
+  bedrooms: string;
+  bathrooms: string;
+  price: string;
+  date: string;
+  address: string;
+  latitude: string;
+  longitude: string;
+}
+
+export type ResaleData = Property[];

--- a/src/app/shared-components/react-mapbox/mapbox-container.tsx
+++ b/src/app/shared-components/react-mapbox/mapbox-container.tsx
@@ -1,12 +1,24 @@
 "use client"
 
+import { useMemo } from "react"
 import * as React from 'react';
+import { ResaleData } from "@/app/map/types"
 import Map from 'react-map-gl';
 import { MAPBOX_API_SECRET_KEY } from "@/app/apiUtils";
 import 'mapbox-gl/dist/mapbox-gl.css';
 
-// Component to encapsulate the Map Box Container to be reusable if we want to use it in multiple places in our NextJS app.
-const MapboxContainer = () => {
+interface MapBoxContainerProps {
+  records: ResaleData
+}
+
+// Encapsulates the Mapbox map and is reusable across the Next.js app.
+const MapboxContainer = ({ records }: MapBoxContainerProps) => {
+
+  /* Memoize the records to prevent unnecessary recalculations on re-renders. Useful
+   * for improving performance when handling static, large datasets from the server. */
+  const memoizedRecords: ResaleData = useMemo(() => records, [records]);
+  console.log(memoizedRecords);
+
   return (
     <Map
       mapboxAccessToken={MAPBOX_API_SECRET_KEY}


### PR DESCRIPTION
This pull request introduces functionality for reading resale data from a CSV file located in the public directory on the server side. The data is parsed and then passed to a reusable React component, which will render it into a Mapbox map on the client side. Key changes include:

- **Helper Function**: Added `readAndParseCSV` to read and parse the CSV file server-side within the "map" app route.
- **TypeScript Interfaces**: Created interfaces to define the structure of the CSV data.
- **MapPage Component Update**: Updated the `MapPage` component to fetch data from the CSV and pass it to the `MapboxContainer`.
- **Performance Optimization**: Enhanced client-side performance by memoizing the records data to optimize re-renders. This is beneficial since this dataset is fetched from the server only once on initial page load and contains over 4000 records. Specific loading of which records will be displayed on the page can be managed in separate state within the component later.

This implementation enables dynamic visualization of resale data on the map, ensuring efficient data handling and an improved user experience.
